### PR TITLE
fixes for firebase client - we use a different project id for firebase :(

### DIFF
--- a/src/svc/firebase.rs
+++ b/src/svc/firebase.rs
@@ -18,11 +18,15 @@ lazy_static! {
 }
 
 impl<'a> Hub<'a> {
-    pub fn get_data<D>(&self, path: &str, opts: GetOptions) -> client::Result<D>
+    pub fn get_data<D>(&self,
+                       firebase_project_id: &str,
+                       path: &str,
+                       opts: GetOptions)
+                       -> client::Result<D>
         where for<'de> D: 'static + Send + Deserialize<'de>
     {
         let uri = Uri::from_str(&format!("https://{}.firebaseio.com/{}.json?shallow={}",
-                                         self.project_id(),
+                                         firebase_project_id,
                                          path,
                                          opts.shallow))
                 .expect("uri is valid");


### PR DESCRIPTION
we should probably just use the same project for datastore and firebase, but right now `qwill` always uses `sigma-1013` for storing dbSpecs in datastore but I believe the app uses `slate-fc6b5` in prod/staging and `storyboard-74d79` in dev.

I tried just making a gcp hub for each project id, but I hit some issue that seemed hard to debug where eventually I'd be doubly mutably borrowing something in the tokio-core library. I gave up on trying to fix that pretty quickly and tried this patch instead.