### PR TITLE
Implement token delegation w/ service accounts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ env_logger = "0.3"
 hyper = "0.11"
 hyper-tls = "0.1"
 futures = "0.1"
-jsonwebtoken = "2.0"
+jsonwebtoken = { git = "https://github.com/mhseiden/jsonwebtoken.git", rev = "05041bb" }
 lazy_static = "0.2"
 log = "0.3"
 openssl = "0.9"

--- a/src/client.rs
+++ b/src/client.rs
@@ -131,13 +131,18 @@ impl<'a> Hub<'a, ::svc::tokeninfo::TokenInfoService> {
     pub fn get_google_auth_pkey(&self, kid: &str) -> Result<auth::PubKey> {
         self.client.auth.get_google_auth_pkey(self, kid)
     }
+    // NOTE this flow is described in the following google documentation
+    //
+    // https://developers.google.com/identity/protocols/OAuth2ServiceAccount#authorizingrequests
+    pub fn delegate(&self, id_token: &str, scopes: &[String]) -> Result<auth::Token> {
+        self.client.auth.delegate(self, id_token, scopes)
+    }
 }
 
 impl<'a, S> ApiClient for Hub<'a, S> {
     fn token(&self, scopes: &[String]) -> Result<auth::Token> {
         self.client.auth.token(self, scopes)
     }
-
     fn request<D: 'static + Send>(&self,
                                   r: hyper::Request<hyper::Body>)
                                   -> Result<(hyper::Headers, D)>
@@ -211,7 +216,7 @@ pub trait ApiClient {
         where for<'de> D: 'static + Send + Deserialize<'de>;
 
     // fetches an access token for use in requests
-    fn token(&self, scopes: &[String]) -> Result<auth::Token>;
+    fn token(&self, &[String]) -> Result<auth::Token>;
 
     // helper method for making a GET request
     fn get<D>(&self, uri: &hyper::Uri, scopes: &[String]) -> Result<D>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,4 @@ pub mod svc;
 
 pub use client::{GoogleCloudClient, Hub};
 pub use client::{Error, ApiError, ErrorDetails, Result};
+pub use auth::Token as BearerToken;

--- a/src/svc/tokeninfo.rs
+++ b/src/svc/tokeninfo.rs
@@ -28,11 +28,9 @@ pub struct TokenInfo {
 }
 
 impl<'a> Hub<'a> {
-    pub fn tokeninfo(&self, scopes: &[String]) -> client::Result<TokenInfo> {
-        let token = self.token(scopes)?;
-
+    pub fn tokeninfo(&self, token: &str, scopes: &[String]) -> client::Result<TokenInfo> {
         let mut uri = String::from(TOKEN_INFO_URI);
-        uri.push_str(&format!("?access_token={}", token.access_token));
+        uri.push_str(&format!("?access_token={}", token));
 
         self.get(&Uri::from_str(&uri).unwrap(), scopes)
     }


### PR DESCRIPTION
It is possible to grant a service account the power to make delegated requests to GCP, by exchanging an email address for an access token. This PR adds a flow for executing this: given a signed id_token (jwt), the lib now validates the token, extracts the email address, and requests the delegated access token.

See the following for more details on the flow.

https://developers.google.com/identity/protocols/OAuth2ServiceAccount#authorizingrequests