### PR TITLE
Don't use a transaction for single-key lookups

### DIFF
--- a/src/svc/datastore.rs
+++ b/src/svc/datastore.rs
@@ -272,6 +272,8 @@ impl<'a> Hub<'a> {
         self.lookup_one(key)
     }
 
+    // Lookup a key using default read options:
+    // https://cloud.google.com/datastore/docs/reference/rest/v1/ReadOptions
     fn lookup_one(&self, key: Key) -> client::Result<Option<ValueMap>> {
         let req = LookupRequest {
             keys: Some(vec![key]),

--- a/src/svc/datastore.rs
+++ b/src/svc/datastore.rs
@@ -273,22 +273,13 @@ impl<'a> Hub<'a> {
     }
 
     fn lookup_one(&self, key: Key) -> client::Result<Option<ValueMap>> {
-        let txn_id = self.begin_transaction()?;
-
-        let read_options = ReadOptions {
-            transaction: Some(txn_id.clone()),
-            ..Default::default()
-        };
-
         let req = LookupRequest {
             keys: Some(vec![key]),
-            read_options: Some(read_options),
+            read_options: None,
         };
 
         let uri = self.mk_uri("lookup");
         let res = self.post::<_, LookupResponse>(&uri, req, &[])?;
-
-        self.commit(&txn_id, CommitRequest::default())?;
 
         Ok(res.found
                .and_then(|mut f| if f.len() != 1 {


### PR DESCRIPTION
Currently a datastore lookup involves 3 api calls. This reduces it to 1.