### PR TITLE
update bigquery service apis to be more 'job' focused

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -44,7 +44,7 @@ impl Token {
         let bearer = hyper::header::Bearer { token: self.access_token };
         hyper::header::Authorization(bearer)
     }
-    fn is_expired(&self) -> bool {
+    pub fn is_expired(&self) -> bool {
         self.expires_at.map_or(true, |at| UTC::now() > at)
     }
 }

--- a/src/svc/common.rs
+++ b/src/svc/common.rs
@@ -1,0 +1,3 @@
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Empty {}

--- a/src/svc/mod.rs
+++ b/src/svc/mod.rs
@@ -1,3 +1,5 @@
+mod common;
+
 pub mod bigquery;
 pub mod cloudkms;
 pub mod datastore;

--- a/src/svc/tokeninfo.rs
+++ b/src/svc/tokeninfo.rs
@@ -1,37 +1,10 @@
-use std::str::FromStr;
-
-use hyper::Uri;
-
 use client::{self, ApiClient};
 
 pub struct TokenInfoService {}
 pub type Hub<'a> = client::Hub<'a, TokenInfoService>;
 
-static TOKEN_INFO_URI: &str = "https://www.googleapis.com/oauth2/v3/tokeninfo";
-
-#[derive(Deserialize, Debug)]
-pub struct TokenInfo {
-    pub iss: Option<String>,
-    pub sub: Option<String>,
-    pub azp: Option<String>,
-    pub aud: Option<String>,
-    pub iat: Option<String>,
-    pub exp: Option<String>,
-
-    pub email: Option<String>,
-    pub email_verified: Option<String>,
-    pub name: Option<String>,
-    pub picture: Option<String>,
-    pub given_name: Option<String>,
-    pub family_name: Option<String>,
-    pub locale: Option<String>,
-}
-
 impl<'a> Hub<'a> {
-    pub fn tokeninfo(&self, token: &str, scopes: &[String]) -> client::Result<TokenInfo> {
-        let mut uri = String::from(TOKEN_INFO_URI);
-        uri.push_str(&format!("?access_token={}", token));
-
-        self.get(&Uri::from_str(&uri).unwrap(), scopes)
+    pub fn access_token(&self, scopes: &[String]) -> client::Result<::auth::Token> {
+        self.token(scopes)
     }
 }


### PR DESCRIPTION
Title says it all! A `query` is just one of a few types of "jobs" you can run in BigQuery, so this generalizes the API to take that into account. The motivating use-case here is to be able to create tables from queries, as well as get the anon-table reference for each query that is run.