### PR TITLE
add support for GQL in datastore svc

### DIFF
--- a/src/svc/datastore.rs
+++ b/src/svc/datastore.rs
@@ -71,13 +71,13 @@ struct GqlQueryParameter {
 #[derive(Deserialize, Default, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RunQueryResponse {
-    batch: QueryResultBatch,
+    pub batch: QueryResultBatch,
 }
 
 #[derive(Deserialize, Default, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryResultBatch {
-    entity_results: Option<Vec<EntityResult>>,
+    pub entity_results: Option<Vec<EntityResult>>,
 }
 
 #[derive(Serialize, Default, Debug)]

--- a/src/svc/datastore.rs
+++ b/src/svc/datastore.rs
@@ -13,14 +13,17 @@ pub type Hub<'a> = client::Hub<'a, DatastoreService>;
 pub type ValueMap = HashMap<String, Value>;
 
 #[derive(Serialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct BeginTransactionRequest {}
 
 #[derive(Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct BeginTransactionResponse {
     pub transaction: String,
 }
 
 #[derive(Serialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct CommitRequest {
     pub transaction: String,
 
@@ -32,17 +35,53 @@ pub struct CommitRequest {
 }
 
 #[derive(Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct CommitResponse {
-    #[serde(rename = "mutationResults")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mutation_results: Option<Vec<MutationResult>>,
 
-    #[serde(rename = "indexUpdates")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub index_updates: Option<i32>,
 }
 
 #[derive(Serialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
+struct RunQueryRequest {
+    partition_id: PartitionId,
+    read_options: ReadOptions,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gql_query: Option<GqlQuery>,
+}
+
+#[derive(Serialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
+struct GqlQuery {
+    query_string: String,
+    allow_literals: bool,
+    named_bindings: HashMap<String, GqlQueryParameter>,
+}
+
+#[derive(Serialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
+struct GqlQueryParameter {
+    value: Value,
+}
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RunQueryResponse {
+    batch: QueryResultBatch,
+}
+
+#[derive(Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryResultBatch {
+    entity_results: Option<Vec<EntityResult>>,
+}
+
+#[derive(Serialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct Mutation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub insert: Option<Entity>,
@@ -53,7 +92,6 @@ pub struct Mutation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub update: Option<Entity>,
 
-    #[serde(rename = "baseVersion")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_version: Option<String>,
 
@@ -62,11 +100,11 @@ pub struct Mutation {
 }
 
 #[derive(Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct MutationResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 
-    #[serde(rename = "conflictDetected")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conflict_detected: Option<bool>,
 
@@ -75,16 +113,17 @@ pub struct MutationResult {
 }
 
 #[derive(Serialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct LookupRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keys: Option<Vec<Key>>,
 
-    #[serde(rename = "readOptions")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub read_options: Option<ReadOptions>,
 }
 
 #[derive(Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct LookupResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub found: Option<Vec<EntityResult>>,
@@ -97,17 +136,18 @@ pub struct LookupResponse {
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct ReadOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction: Option<String>,
 
-    #[serde(rename = "readConsistency")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub read_consistency: Option<String>,
 }
 
 
 #[derive(Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct EntityResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
@@ -120,6 +160,7 @@ pub struct EntityResult {
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct Entity {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<HashMap<String, Value>>,
@@ -129,15 +170,16 @@ pub struct Entity {
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct Key {
     pub path: Vec<PathElement>,
 
-    #[serde(rename = "partitionId")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub partition_id: Option<PartitionId>,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct PathElement {
     pub kind: String,
 
@@ -149,57 +191,47 @@ pub struct PathElement {
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct PartitionId {
-    #[serde(rename = "projectId")]
     pub project_id: String,
 
-    #[serde(rename = "namespaceId")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct Value {
-    #[serde(rename = "entityValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entity_value: Option<Entity>,
 
-    #[serde(rename = "timestampValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp_value: Option<String>,
 
-    #[serde(rename = "stringValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub string_value: Option<String>,
 
-    #[serde(rename = "doubleValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub double_value: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub meaning: Option<i32>,
 
-    #[serde(rename = "excludeFromIndexes")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exclude_from_indexes: Option<bool>,
 
-    #[serde(rename = "blobValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blob_value: Option<String>,
 
-    #[serde(rename = "keyValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key_value: Option<Key>,
 
-    #[serde(rename = "booleanValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub boolean_value: Option<bool>,
 
-    #[serde(rename = "integerValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub integer_value: Option<String>,
+    pub integer_value: Option<i64>,
 
-    #[serde(rename = "nullValue")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub null_value: Option<String>,
 
@@ -284,6 +316,32 @@ impl<'a> Hub<'a> {
     ) -> client::Result<Option<ValueMap>> {
         let key = self.mk_key(kind, Some(ns), ancestors, Some(name), None);
         self.lookup_one(key)
+    }
+
+    pub fn gql<B>(&self, ns: &str, q: &str, bindings: B) -> client::Result<RunQueryResponse>
+    where
+        B: IntoIterator<Item = (String, Value)>,
+    {
+        let query = GqlQuery {
+            query_string: q.to_string(),
+            allow_literals: false,
+            named_bindings: bindings
+                .into_iter()
+                .map(|(k, v)| (k, GqlQueryParameter { value: v }))
+                .collect(),
+        };
+
+        let req = RunQueryRequest {
+            partition_id: PartitionId {
+                project_id: self.project_id().to_string(),
+                namespace_id: Some(ns.to_string()),
+            },
+            read_options: ReadOptions { ..Default::default() },
+            gql_query: Some(query),
+        };
+
+        let uri = self.mk_uri("runQuery");
+        self.post::<_, RunQueryResponse>(&uri, req, &[])
     }
 
     // Lookup a key using default read options:


### PR DESCRIPTION
This PR adds some pretty narrow support for submitting GQL queries. It doesn't allow the full API flexibility...but idk that allowing literals in a query like this is ever a good idea so I'm ok with that for now!